### PR TITLE
Adds border-radius property to #autocomplete-list in home.css.

### DIFF
--- a/artadosearch/css/home.css
+++ b/artadosearch/css/home.css
@@ -95,7 +95,8 @@
         background-color: #fff;
         display: none;
         text-align: left;
-        border-radius: 9px;
+        border-bottom-right-radius: 10px;
+        border-bottom-left-radius: 10px;
     }
 
         #autocomplete-list li {

--- a/artadosearch/css/home.css
+++ b/artadosearch/css/home.css
@@ -94,7 +94,8 @@
         overflow-y: auto;
         background-color: #fff;
         display: none;
-        text-align: left
+        text-align: left;
+        border-radius: 9px;
     }
 
         #autocomplete-list li {


### PR DESCRIPTION
Adds border-radius property to #autocomplete-list in home.css.

(I think rounding the search part would look nice and is necessary for Artado-search.)

The feature is completely safe and tested.

@ardatdev  @Arnolxu