### PR TITLE
Search.aspx fix

### DIFF
--- a/artadosearch/search.aspx.cs
+++ b/artadosearch/search.aspx.cs
@@ -588,20 +588,6 @@ namespace artadosearch
                             suggestions.DataSource = ResultsClass.Artado(query, 0, null);
                         }
                         suggestions.DataBind();
-
-                        //PriEco Results
-                        DataTable dt;
-                        if (cookie != null && cookie.Value != null)
-                        {
-                            dt = JsonConvert.DeserializeObject<DataTable>(ResultsClass.PriEco(query, 10, safeS, cookie.Value));
-                        }
-                        else
-                        {
-                            dt = JsonConvert.DeserializeObject<DataTable>(ResultsClass.PriEco(query, 10, safeS, null));
-                        }
-                        
-                        artado_results.DataSource = dt;
-                        artado_results.DataBind();
                         break;
 
                     case "Bing":

--- a/artadosearch/search.aspx.cs
+++ b/artadosearch/search.aspx.cs
@@ -589,26 +589,19 @@ namespace artadosearch
                         }
                         suggestions.DataBind();
 
-                        try
+                        //PriEco Results
+                        DataTable dt;
+                        if (cookie != null && cookie.Value != null)
                         {
-                            //PriEco Results
-                            DataTable dt;
-                            if (cookie != null && cookie.Value != null)
-                            {
-                                dt = JsonConvert.DeserializeObject<DataTable>(ResultsClass.PriEco(query, 10, safeS, cookie.Value));
-                            }
-                            else
-                            {
-                                dt = JsonConvert.DeserializeObject<DataTable>(ResultsClass.PriEco(query, 10, safeS, null));
-                            }
-
-                            artado_results.DataSource = dt;
-                            artado_results.DataBind();
+                            dt = JsonConvert.DeserializeObject<DataTable>(ResultsClass.PriEco(query, 10, safeS, cookie.Value));
                         }
-                        catch
+                        else
                         {
-                            artado_results.Visible = false;
+                            dt = JsonConvert.DeserializeObject<DataTable>(ResultsClass.PriEco(query, 10, safeS, null));
                         }
+                        
+                        artado_results.DataSource = dt;
+                        artado_results.DataBind();
                         break;
 
                     case "Bing":


### PR DESCRIPTION
This Fix causes slowness issues in Artado search. When I select "Artado" in the search section and try to search, the website slows down, but there is no problem in Google. @Arnolxu

The problem was solved by LinuxUsersLinuxMint.