### PR TITLE
Description and Artado--Project company name have been added to the Artado-Search\Properties\assemblyinfo.cs file.

### DIFF
--- a/artadosearch/Properties/AssemblyInfo.cs
+++ b/artadosearch/Properties/AssemblyInfo.cs
@@ -6,9 +6,9 @@ using System.Runtime.InteropServices;
 // denetlenir. Bir derlemeyle ilişkilendirilmiş bilgileri değiştirmek için bu
 // öznitelik değerlerini değiştirin.
 [assembly: AssemblyTitle("artadosearch")]
-[assembly: AssemblyDescription("")]
+[assembly: AssemblyDescription("Artado Search is open source, private and highly customizable search engine.")]
 [assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("")]
+[assembly: AssemblyCompany("Artado-Project")]
 [assembly: AssemblyProduct("artadosearch")]
 [assembly: AssemblyCopyright("Copyright ©  2023")]
 [assembly: AssemblyTrademark("")]


### PR DESCRIPTION
"Description" and "Company name/Organization" have been added to the "Description" and "Company" sections of the Properties file. Please check the code for more detailed information about the pull request. @ardatdev @Arnolxu