### PR TITLE
For "Artado-Search" Menu, add "font-family: Arial;" to ".mb-3" class in "mdb.min.css" file. has been added.

### DIFF
--- a/artadosearch/css/mdb.min.css
+++ b/artadosearch/css/mdb.min.css
@@ -7709,7 +7709,8 @@ textarea.form-control-lg {
 }
 
 .mb-3 {
-	margin-bottom: 1rem !important
+	margin-bottom: 1rem !important;
+	font-family: Arial;
 }
 
 .mb-4 {


### PR DESCRIPTION
For "Artado-Search" Menu, add "font-family: Arial;" to ".mb-3" class in "mdb.min.css" file. has been added. I think the "Arial" font is more beautiful. I remember that these texts used to have "Arial" font on the website.

@ardatdev @Arnolxu 